### PR TITLE
Read runtime settings from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Django settings
+SECRET_KEY=your-secret-key
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# Database configuration
+POSTGRES_DB=gestor_procedimentos_db
+POSTGRES_USER=gestor_user
+POSTGRES_PASSWORD=gestor_password
+POSTGRES_NAME=gestor_procedimentos_db
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+
+DJANGO_SETTINGS_MODULE=config.settings
+PYTHONUNBUFFERED=1

--- a/gestor-procedimentos/config/settings.py
+++ b/gestor-procedimentos/config/settings.py
@@ -26,12 +26,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-3gkukvv9d99mrgh=p55g*i_de1k$o6nusz!ed8@je3vil%v-q+'
+SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-change-me')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DEBUG', 'True') == 'True'
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
 # Permitir requisições de qualquer origem (para testes)
 CORS_ALLOW_ALL_ORIGINS = True
 


### PR DESCRIPTION
## Summary
- read `SECRET_KEY`, `DEBUG` and `ALLOWED_HOSTS` from environment
- provide example environment file

## Testing
- `SECRET_KEY=tmp DEBUG=True ALLOWED_HOSTS=localhost POSTGRES_NAME=test POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_HOST=localhost POSTGRES_PORT=5432 python gestor-procedimentos/manage.py check --settings=config.settings` *(fails: Could not import Django)*